### PR TITLE
[ST] Make it possible to run KRaft upgrade/downgrade tests with UTO in GA

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/upgrade/VersionModificationDataLoader.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/upgrade/VersionModificationDataLoader.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 /**
@@ -120,7 +121,7 @@ public class VersionModificationDataLoader {
         List<TestKafkaVersion> sortedVersions = TestKafkaVersion.getSupportedKafkaVersions();
         TestKafkaVersion latestKafkaSupported = sortedVersions.get(sortedVersions.size() - 1);
 
-        BundleVersionModificationData acrossUpgradeData = getBundleUpgradeOrDowngradeData(getBundleUpgradeOrDowngradeDataList().size() - 1);
+        BundleVersionModificationData acrossUpgradeData = getBundleUpgradeOrDowngradeData(0);
         BundleVersionModificationData startingVersion = acrossUpgradeData;
 
         startingVersion.setDefaultKafka(acrossUpgradeData.getDefaultKafkaVersionPerStrimzi());
@@ -160,14 +161,14 @@ public class VersionModificationDataLoader {
     }
 
     public static Stream<Arguments> loadYamlDowngradeData() {
-        return loadYamlDowngradeDataWithFeatureGates(null);
+        return loadYamlDowngradeDataWithFeatureGates(null, false);
     }
 
     public static Stream<Arguments> loadYamlDowngradeDataForKRaft() {
-        return loadYamlDowngradeDataWithFeatureGates(KRAFT_UPGRADE_FEATURE_GATES);
+        return loadYamlDowngradeDataWithFeatureGates(KRAFT_UPGRADE_FEATURE_GATES, true);
     }
 
-    public static Stream<Arguments> loadYamlDowngradeDataWithFeatureGates(String featureGates) {
+    public static Stream<Arguments> loadYamlDowngradeDataWithFeatureGates(String featureGates, boolean isKRaft) {
         VersionModificationDataLoader dataLoader = new VersionModificationDataLoader(ModificationType.BUNDLE_DOWNGRADE);
         List<Arguments> parameters = new LinkedList<>();
 
@@ -178,6 +179,12 @@ public class VersionModificationDataLoader {
         UpgradeKafkaVersion procedures = new UpgradeKafkaVersion(testKafkaVersion.version());
 
         dataLoader.getBundleUpgradeOrDowngradeDataList().forEach(downgradeData -> {
+            if (isKRaft && skipTestCaseIfWrongFeatureGatesAreUsedInKRaft(downgradeData)) {
+                // if we are running KRaft upgrade/downgrade tests and we are setting "wrong" feature gates in the upgrade/downgrade YAML
+                // we should skip this scenario
+                return;
+            }
+
             downgradeData.setProcedures(procedures);
 
             downgradeData = updateUpgradeDataWithFeatureGates(downgradeData, featureGates);
@@ -189,14 +196,14 @@ public class VersionModificationDataLoader {
     }
 
     public static Stream<Arguments> loadYamlUpgradeData() {
-        return loadYamlUpgradeDataWithFeatureGates(null);
+        return loadYamlUpgradeDataWithFeatureGates(null, false);
     }
 
     public static Stream<Arguments> loadYamlUpgradeDataForKRaft() {
-        return loadYamlUpgradeDataWithFeatureGates(KRAFT_UPGRADE_FEATURE_GATES);
+        return loadYamlUpgradeDataWithFeatureGates(KRAFT_UPGRADE_FEATURE_GATES, true);
     }
 
-    public static Stream<Arguments> loadYamlUpgradeDataWithFeatureGates(String featureGates) {
+    public static Stream<Arguments> loadYamlUpgradeDataWithFeatureGates(String featureGates, boolean isKRaft) {
         VersionModificationDataLoader upgradeDataList = new VersionModificationDataLoader(ModificationType.BUNDLE_UPGRADE);
         List<Arguments> parameters = new LinkedList<>();
 
@@ -207,6 +214,12 @@ public class VersionModificationDataLoader {
         UpgradeKafkaVersion procedures = new UpgradeKafkaVersion(testKafkaVersion.version());
 
         upgradeDataList.getBundleUpgradeOrDowngradeDataList().forEach(upgradeData -> {
+            if (isKRaft && skipTestCaseIfWrongFeatureGatesAreUsedInKRaft(upgradeData)) {
+                // if we are running KRaft upgrade/downgrade tests and we are setting "wrong" feature gates in the upgrade/downgrade YAML
+                // we should skip this scenario
+                return;
+            }
+
             upgradeData.setProcedures(procedures);
 
             upgradeData = updateUpgradeDataWithFeatureGates(upgradeData, featureGates);
@@ -243,5 +256,11 @@ public class VersionModificationDataLoader {
         }
 
         return upgradeData;
+    }
+
+    private static boolean skipTestCaseIfWrongFeatureGatesAreUsedInKRaft(BundleVersionModificationData data) {
+        Predicate<String> isUtoDisabled = featureGates -> featureGates.contains("-UnidirectionalTopicOperator");
+
+        return isUtoDisabled.test(data.getFeatureGatesBefore()) || isUtoDisabled.test(data.getFeatureGatesAfter());
     }
 }

--- a/systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
+++ b/systemtest/src/test/resources/upgrade/BundleDowngrade.yaml
@@ -29,7 +29,6 @@
 #    kafkaKRaftBefore: path to Kafka and KafkaNodePool resources (KRaft mode), collected in one file, in the version of Strimzi, from which we are doing the downgrade
 #    kafkaKRaftAfter: path to Kafka and KafkaNodePool resources (KRaft mode), collected in one file, in the version of Strimzi, to which we are doing the downgrade
 # --- Structure ---
-  
 - fromVersion: HEAD
   toVersion: 0.40.0
   fromExamples: HEAD
@@ -52,7 +51,7 @@
     flakyEnvVariable: none
     reason: Test is working on all environment used by QE.
   featureGatesBefore: ""
-  featureGatesAfter: "-UnidirectionalTopicOperator"
+  featureGatesAfter: ""
   filePaths:
     kafkaBefore: "/examples/kafka/kafka-persistent.yaml"
     kafkaAfter: "/examples/kafka/kafka-persistent.yaml"
@@ -80,7 +79,7 @@
     flakyEnvVariable: none
     reason: Test is working on all environment used by QE.
   featureGatesBefore: ""
-  featureGatesAfter: ""
+  featureGatesAfter: "-UnidirectionalTopicOperator"
   filePaths:
     kafkaBefore: "/examples/kafka/kafka-persistent.yaml"
     kafkaAfter: "/examples/kafka/kafka-persistent.yaml"

--- a/systemtest/src/test/resources/upgrade/BundleUpgrade.yaml
+++ b/systemtest/src/test/resources/upgrade/BundleUpgrade.yaml
@@ -54,3 +54,28 @@
     kafkaAfter: "/examples/kafka/kafka-persistent.yaml"
     kafkaKRaftBefore: "/examples/kafka/kraft/kafka.yaml"
     kafkaKRaftAfter: "/examples/kafka/kraft/kafka.yaml"
+- fromVersion: 0.40.0
+  fromExamples: strimzi-0.40.0
+  oldestKafka: 3.6.0
+  fromUrl: https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.40.0/strimzi-0.40.0.zip
+  fromKafkaVersionsUrl: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.40.0/kafka-versions.yaml
+  additionalTopics: 2
+  imagesAfterOperations:
+    zookeeper: strimzi/kafka:latest-kafka-3.7.0
+    kafka: strimzi/kafka:latest-kafka-3.7.0
+    topicOperator: strimzi/operator:latest
+    userOperator: strimzi/operator:latest
+  client:
+    continuousClientsMessages: 500
+  environmentInfo:
+    maxK8sVersion: latest
+    status: stable
+    flakyEnvVariable: none
+    reason: Test is working on environment, where k8s server version is < 1.22
+  featureGatesBefore: "-UnidirectionalTopicOperator"
+  featureGatesAfter: ""
+  filePaths:
+    kafkaBefore: "/examples/kafka/kafka-persistent.yaml"
+    kafkaAfter: "/examples/kafka/kafka-persistent.yaml"
+    kafkaKRaftBefore: "/examples/kafka/kraft/kafka.yaml"
+    kafkaKRaftAfter: "/examples/kafka/kraft/kafka.yaml"


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR adds a small workaround for running KRaft upgrade/downgrade tests now with UTO in GA.
In case that we have `-UnidirectionalTopicOperator` in the feature gates of the upgrade/downgrade YAML file, the scenario will be simply skipped.

The whole process should be a bit changed, but to unblock the promotion of UTO to GA, I decided to do it this way now.

### Checklist

- [ ] Make sure all tests pass

